### PR TITLE
에딧 컨트롤러 수정

### DIFF
--- a/WanderBoard/Controllers/DetailPage/DetailInputViewController.swift
+++ b/WanderBoard/Controllers/DetailPage/DetailInputViewController.swift
@@ -1365,18 +1365,33 @@ extension DetailInputViewController: UITextViewDelegate {
 
                if textView.textColor == placeholderColor {
                    textView.text = nil
-                   textView.textColor = .lightgray
+                   textView.textColor = .font
                }
            }
     
     func textViewDidEndEditing(_ textView: UITextView) {
+        let placeholderColor: UIColor = {
+                   if traitCollection.userInterfaceStyle == .dark {
+                       return UIColor.darkgray
+                   } else {
+                       return UIColor.lightgray
+                   }
+               }()
+        
         if textView.text.isEmpty {
-            if textView == mainTextField {
-                textView.text = "여행 제목을 입력해주세요."
-            } else if textView == subTextField {
-                textView.text = "기록을 담아 주세요."
-            }
-            textView.textColor = .lightgray
+                    let placeholderText: String = {
+                        if textView == mainTextField {
+                            return "여행 제목을 입력해주세요."
+                        } else if textView == subTextField {
+                            return "기록을 담아 주세요."
+                        } else {
+                            return ""
+                        }
+                    }()
+            textView.text = placeholderText
+            textView.textColor = placeholderColor
+        } else {
+            textView.textColor = .font
         }
     }
     

--- a/WanderBoard/Controllers/MyPage/EditViewController.swift
+++ b/WanderBoard/Controllers/MyPage/EditViewController.swift
@@ -15,9 +15,11 @@ import CoreData
 class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewControllerDelegate {
     
     let doneButton = UIButton()
-    let addImage = UIImageView().then(){
-        $0.image = UIImage(systemName: "plus")
-        $0.tintColor = UIColor(named: "textColorSub")
+    let addImage = UIImageView().then {
+        let config = UIImage.SymbolConfiguration(weight: .bold)
+        $0.image = UIImage(systemName: "plus", withConfiguration: config)
+        $0.tintColor = .lightblack
+        $0.contentMode = .scaleAspectFit
     }
     let addImageLayer = UIView().then(){
         $0.backgroundColor = UIColor(white: 1, alpha: 0.7)
@@ -72,17 +74,19 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(imageViewTapped(tapGestureRecognizer:)))
         profile.isUserInteractionEnabled = true
         profile.addGestureRecognizer(tapGestureRecognizer)
+        
+        doneButton.isEnabled = false
     }
     
     override func configureUI(){
         doneButton.setTitle("Done", for: .normal)
-        doneButton.setTitleColor(.font, for: .normal)
+        doneButton.setTitleColor(.lightgray, for: .normal)
         doneButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
         doneButton.addTarget(self, action: #selector(moveToMyPage), for: .touchUpInside)
         let barButtonItem = UIBarButtonItem(customView: doneButton)
         self.navigationItem.rightBarButtonItem = barButtonItem
         
-        profile.image = UIImage(named: "person.crop.circle")
+        profile.image = previousImage
         profile.clipsToBounds = true
         profile.contentMode = .scaleAspectFill
         profile.layer.cornerRadius = 53
@@ -317,7 +321,12 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
     
     @objc private func duplicateCheckTapped() {
         guard let nickname = nicknameTextField.text, !nickname.isEmpty else {
-            showAlert(title: "😗", message: "변경할 닉네임을 입력해주세요. \n입력하신 닉네임은 다른 사용자에게 노출됩니다.🤭")
+            showAlert(title: "😗", message: "변경할 닉네임을 입력해주세요 \n입력하신 닉네임은 다른 사용자에게 노출됩니다")
+            return
+        }
+        
+        if nickname.count < 2 || nickname.count > 16 {
+            showAlert(title: "😱", message: "글자 수를 맞춰주세요 \n 닉네임은 2자 이상, 16자 이하여야 합니다")
             return
         }
         
@@ -325,7 +334,7 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
         let nicknamePattern = "^[a-zA-Z0-9가-힣]+$"
         let nicknamePredicate = NSPredicate(format: "SELF MATCHES %@", nicknamePattern)
         if !nicknamePredicate.evaluate(with: nickname) {
-            showAlert(title: "🤬", message: "닉네임에 특수문자를 포함할 수 없습니다.")
+            showAlert(title: "🤬", message: "닉네임에 특수문자를 포함할 수 없습니다")
             return
         }
         
@@ -333,9 +342,9 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
             do {
                 let isDuplicate = try await FirestoreManager.shared.checkDisplayNameExists(displayName: nickname)
                 if isDuplicate {
-                    showAlert(title: "😱", message: "아쉽네요. 다른 사용자가 먼저 등록했어요")
+                    showAlert(title: "😱", message: "아쉽네요.. 다른 사용자가 먼저 등록했어요")
                 } else {
-                    showConfirmationAlert(title: "😁\n\(nickname)", message: "당신만의 멋진 닉네임이네요. \n이 닉네임을 사용하시겠습니까?", nickname: nickname)
+                    showConfirmationAlert(title: "😁\n\(nickname)", message: "당신만의 멋진 닉네임이네요! \n이 닉네임을 사용하시겠습니까?", nickname: nickname)
                 }
             } catch {
                 showAlert(title: "😵‍💫", message: "닉네임 확인 중 오류가 발생했습니다: \(error.localizedDescription)")
@@ -361,23 +370,32 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
             self.duplicateCheckButton.isEnabled = false
             let babyGTocustomB = traitCollection.userInterfaceStyle == .dark ? UIColor(named: "customblack") : UIColor(named: "babygray")
             self.duplicateCheckButton.backgroundColor = babyGTocustomB
+            updateDoneButtonState()
         }
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel) { [weak self] _ in
             guard let self = self else { return }
-            self.nicknameTextField.text = ""
             self.nicknameTextField.isEnabled = true
             self.duplicateCheckButton.isEnabled = true
-            let lightGTodarkG = traitCollection.userInterfaceStyle == .dark ? UIColor(named: "darkgray") : UIColor(named: "lightgray")
-            self.duplicateCheckButton.backgroundColor = lightGTodarkG
-            let darkGTolightG = traitCollection.userInterfaceStyle == .dark ? UIColor(named: "lightgray") : UIColor(named: "darkgray")
-            self.nicknameTextField.textColor = darkGTolightG
         }
         
         alert.addAction(useAction)
         alert.addAction(cancelAction)
         
         present(alert, animated: true, completion: nil)
+    }
+    
+    //저장버튼은 이 경우에서만 활성화 되도록
+    private func updateDoneButtonState() {
+        let isImageSelected = profile.image != previousImage
+        let isNicknameVaild = isNicknameValid(nicknameTextField.text)
+        doneButton.isEnabled = isImageSelected || isNicknameVaild
+        doneButton.setTitleColor(.font, for: .normal)
+    }
+    
+    private func isNicknameValid(_ nickname: String?) -> Bool {
+        guard let nickname = nickname, !nickname.isEmpty else { return false }
+        return nickname.count >= 2 && nickname.count <= 16 && nickname.range(of: "^[a-zA-Z0-9가-힣]+$", options: .regularExpression) != nil
     }
     
     //작성완료시 엔터 누르면 키보드 내려가기
@@ -394,6 +412,7 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
             self.addImageLayer.backgroundColor = UIColor(white: 1, alpha: 0.7)
             self.addImage.image = UIImage(systemName: "plus")
             self.addImage.tintColor = UIColor.textColorSub
+            self.updateDoneButtonState()
         }
         let selectImage = UIAlertAction(title: "새로운 사진 등록", style: .default) { _ in
             var configuration = PHPickerConfiguration()
@@ -412,8 +431,6 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
             alert.addAction($0)
         }
         present(alert, animated: true, completion: nil)
-        self.addImageLayer.backgroundColor = UIColor(white: 1, alpha: 0)
-        self.addImage.tintColor = UIColor.clear
     }
     
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
@@ -427,11 +444,12 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
                     if let selectedImage = image as? UIImage {
                         self?.profile.image = selectedImage
                         self?.addImageLayer.backgroundColor = .clear
-                        self?.addImage.tintColor = UIColor.clear
+                        self?.addImage.tintColor = .clear
                     }
                 }
             }
         }
+        updateDoneButtonState()
     }
     
     override func updateColor() {
@@ -454,6 +472,10 @@ class EditViewController: BaseViewController, UITextFieldDelegate, PHPickerViewC
         
         let withdrawalColor = traitCollection.userInterfaceStyle == .dark ? UIColor(named: "lightblack") : UIColor(named: "lightgray")
         withdrawalB.setTitleColor(withdrawalColor, for: .normal)
+        
+        let doneButtonCollor = traitCollection.userInterfaceStyle == .dark ? UIColor(named: "lightblack") : UIColor(named: "lightgray")
+        doneButton.setTitleColor(doneButtonCollor, for: .normal)
+        
     }
     
     // ManagedObjectContext 가져오기


### PR DESCRIPTION
- 수정을 완료해야지만 done버튼 활성화 되도록
- 글자수 채우지 못하면 글자수 채워야한다는 알림 나오게
- 마이페이지에서 에딧 들어갔을때 프로필에는 전 사진과 불투명한 레이어, 플러스 버튼이 함께 나옴(프로필사진 수정 영역이ㅣ 어딘지 명확하게 하기 위해)/ 수정을 하면 사라짐